### PR TITLE
Added different API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,4 @@ paket-files/
 __pycache__/
 *.pyc
 RTTicTacToe\.WebApi/CQRSGame\.db
+/RTTicTacToe.CQRS.Database/*.db

--- a/Frontend/XF/RTTicTacToe.Forms/App.xaml.cs
+++ b/Frontend/XF/RTTicTacToe.Forms/App.xaml.cs
@@ -10,8 +10,11 @@ namespace RTTicTacToe.Forms
 {
     public partial class App : Application
     {
-        public static string AzureBackendUrl = "https://rttictactoe.azurewebsites.net";
-        //public static string AzureBackendUrl = "https://localhost:44397";
+        public static string AzureBackendUrl = "https://rttictactoe.azurewebsites.net";         // Dev env
+        //public static string AzureBackendUrl = "https://localhost:44397";                     // IIS with Swagger
+        //public static string AzureBackendUrl = "http://localhost:5000";                       // Console
+        //public static string AzureBackendUrl = "http://10.0.2.2:5000";                        // Android emulator => localhost:5000
+        //public static string AzureBackendUrl = "http://10.0.2.2:44397";                       // Android emulator => localhost:44397
 
         public App()
         {

--- a/RTTicTacToe.WebApi/Properties/launchSettings.json
+++ b/RTTicTacToe.WebApi/Properties/launchSettings.json
@@ -20,7 +20,7 @@
     "RTTicTacToe.WebApi": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/values",
+      "launchUrl": "api/game/about",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },


### PR DESCRIPTION
Changes:
* Some devs like me love more to work via emulators and have an end-to-end working solution. `10.0.2.2` is ip, which makes it work backend running on localhost + Android emulator.
* Added `.db` to ignore list.
* `http://localhost:5000/api/game/about` is opened automatically if running backend via console.